### PR TITLE
[Feat/add bcc] Allow user to opt-in to follow up emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-share": "^2.3.1",
         "sitemap": "^2.1.0",
         "swr": "^0.5.3",
-        "universal-fetch": "^1.0.0"
+        "universal-fetch": "^1.0.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@wdio/cli": "^7.0.9",
@@ -10141,7 +10142,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -18919,8 +18919,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-share": "^2.3.1",
     "sitemap": "^2.1.0",
     "swr": "^0.5.3",
-    "universal-fetch": "^1.0.0"
+    "universal-fetch": "^1.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@wdio/cli": "^7.0.9",

--- a/src/components/PersonalInfoForm/index.js
+++ b/src/components/PersonalInfoForm/index.js
@@ -9,6 +9,9 @@ import {
   NameLabelText,
   CcpaOrGdprText,
   CcpaOrGdprHelperText,
+  FollowUpLabelText,
+  YesFollowUpLabelText,
+  NoFollowUpLabelText,
   SubmitButtonText,
   ReadMore,
   RequestChoice,
@@ -55,6 +58,7 @@ class Form extends Component {
       hasSubmit: false,
       regulationType: "GDPR",
       requestType: "DELETION",
+      followUp: "YES",
       screenHeight: typeof window !== "undefined" ? window.innerHeight : null,
     };
 
@@ -324,6 +328,31 @@ class Form extends Component {
               value={this.props.selectedCompany.url}
             />
           )}
+          <FormControl
+            variant="outlined"
+            focused={true}
+            component="fieldset"
+            className={classes.formControl}
+          >
+            <FormLabel>{FollowUpLabelText}</FormLabel>
+            <RadioGroup
+              name="followup1"
+              className={classes.group}
+              onChange={this.handleInput("followUp")}
+              value={this.state.followUp}
+            >
+              <FormControlLabel
+                value="YES"
+                control={<Radio />}
+                label={YesFollowUpLabelText}
+              />
+              <FormControlLabel
+                value="NO"
+                control={<Radio />}
+                label={NoFollowUpLabelText}
+              />
+            </RadioGroup>
+          </FormControl>
           <div>
             <Button
               variant="contained"

--- a/src/components/PersonalInfoForm/index.js
+++ b/src/components/PersonalInfoForm/index.js
@@ -44,6 +44,7 @@ import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import { isMobile } from "react-device-detect";
 import { searchOrganizationsUrlAnchor } from "../../utils/urlAnchors";
+import { v4 as uuidv4 } from 'uuid';
 
 const screenHeightBreakpoint = 560;
 
@@ -139,10 +140,16 @@ class Form extends Component {
   renderMailTo() {
     const { selectedCompany } = this.props;
     const requestType = this.state.requestType;
+    const followUp = this.state.followUp;
 
     const to = selectedCompany
       ? selectedCompany.email
       : this.state.companyEmail;
+
+    const bcc =
+      followUp === "YES"
+        ? `${uuidv4()}@inbound.yourdigitalrights.org`
+        : null;
 
     const companyName = selectedCompany
       ? selectedCompany.name
@@ -160,6 +167,7 @@ class Form extends Component {
 
     return mailtoLink({
       to,
+      bcc,
       subject: subject,
       body: body,
     });

--- a/src/components/PersonalInfoForm/index.js
+++ b/src/components/PersonalInfoForm/index.js
@@ -12,6 +12,7 @@ import {
   FollowUpLabelText,
   YesFollowUpLabelText,
   NoFollowUpLabelText,
+  FollowUpDetailsText,
   SubmitButtonText,
   ReadMore,
   RequestChoice,
@@ -37,6 +38,7 @@ import tracking from "../../utils/tracking";
 import { withStyles } from "@material-ui/core/styles";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormControl from "@material-ui/core/FormControl";
+import FormHelperText from '@material-ui/core/FormHelperText';
 import FormLabel from "@material-ui/core/FormLabel";
 import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
@@ -352,6 +354,9 @@ class Form extends Component {
                 label={NoFollowUpLabelText}
               />
             </RadioGroup>
+            <FormHelperText>
+              {FollowUpDetailsText}
+            </FormHelperText>
           </FormControl>
           <div>
             <Button

--- a/src/components/PersonalInfoForm/text.js
+++ b/src/components/PersonalInfoForm/text.js
@@ -95,6 +95,13 @@ export const NoFollowUpLabelText = (
   />
 );
 
+export const FollowUpDetailsText = (
+  <FormattedMessage
+    id="FollowUpDetails"
+    defaultMessage="In order to send you a reminder, we will need to store your email, name and additional identifying information. In the next step you'll see our email on the BCC section of the form. Please keep it there so we can inform you when the time comes to follow up. We will only use this data to remind you to follow up and then it will be removed from our database."
+  />
+);
+
 export const SubmitButtonText = (
   <FormattedMessage id="sendButton" defaultMessage="Review your request" />
 );

--- a/src/components/PersonalInfoForm/text.js
+++ b/src/components/PersonalInfoForm/text.js
@@ -74,6 +74,27 @@ export const IdentifyingInfoHelperText = (
   />
 );
 
+export const FollowUpLabelText = (
+  <FormattedMessage
+    id="FollowUpLabel"
+    defaultMessage="As stated in the legislation, you are entitled to follow up after your initial request. Would you like us to remind you to follow up?"
+  />
+);
+
+export const YesFollowUpLabelText = (
+  <FormattedMessage
+    id="YesFollowUpLabel"
+    defaultMessage="Yes, please remind me"
+  />
+);
+
+export const NoFollowUpLabelText = (
+  <FormattedMessage
+    id="NoFollowUpLabel"
+    defaultMessage="No, I don't need a reminder"
+  />
+);
+
 export const SubmitButtonText = (
   <FormattedMessage id="sendButton" defaultMessage="Review your request" />
 );


### PR DESCRIPTION
This adds two radio buttons to the form, allowing users to specify if they want to be followed up with.

Note that the text has been altered slightly. Mainly, to reference other fields that will be temporarily stored in Dynamo (cf https://github.com/your-digital-rights/yourdigitalrights.org/issues/161). Let me know if further edits are needed—especially edits that make the text more clear and human for users.

Notes:
- The default is currently "YES". Should we switch to the more data-friendly "No"?
- Although this should work, given the Python Lambda that is set up to listen for inbound emails, work on https://github.com/your-digital-rights/yourdigitalrights.org/issues/159 is needed to ensure all fields are captured. We may want to hold on merging this until 159 is done. However, I wanted to open this incremental PR to get feedback, particularly on copy.

https://github.com/your-digital-rights/yourdigitalrights.org/issues/160