### PR TITLE
feat: adding language to the folow ups table. aligning property names with AWS CDK

### DIFF
--- a/setup/dynamo-tables.js
+++ b/setup/dynamo-tables.js
@@ -13,35 +13,18 @@ const tables = [
   {
     TableName: 'Requests',
     KeySchema: [       
-      { AttributeName: 'uuid', KeyType: 'HASH' },
+      { AttributeName: 'id', KeyType: 'HASH' },
     ],
     AttributeDefinitions: [
-      { AttributeName: 'uuid', AttributeType: 'S' },
-      { AttributeName: 'requestCreatedAt', AttributeType: 'S' },
+      { AttributeName: 'id', AttributeType: 'S' },
       { AttributeName: 'requestType', AttributeType: 'S' },
       { AttributeName: 'regulationType', AttributeType: 'S' },
-      { AttributeName: 'orgName', AttributeType: 'S' },
+      { AttributeName: 'companyName', AttributeType: 'S' },
     ],
     BillingMode: 'PAY_PER_REQUEST',
     GlobalSecondaryIndexes: [
       {
-        IndexName: 'request_created_at_index',
-        KeySchema: [
-          {
-            AttributeName: 'regulationType',
-            KeyType: 'HASH',
-          },
-          {
-            AttributeName: 'requestCreatedAt',
-            KeyType: 'RANGE',
-          }
-        ],
-        Projection: {
-          ProjectionType: 'ALL'
-        },
-      },
-      {
-        IndexName: 'request_type_index',
+        IndexName: 'RequestTypeIndex',
         KeySchema: [
           {
             AttributeName: 'requestType',
@@ -53,7 +36,7 @@ const tables = [
         },
       },
       {
-        IndexName: 'regulation_type_index',
+        IndexName: 'RegulationTypeIndex',
         KeySchema: [
           {
             AttributeName: 'regulationType',
@@ -65,10 +48,10 @@ const tables = [
         },
       },
       {
-        IndexName: 'org_name_index',
+        IndexName: 'CompanyNameIndex',
         KeySchema: [
           {
-            AttributeName: 'orgName',
+            AttributeName: 'companyName',
             KeyType: 'HASH',
           }
         ],
@@ -81,25 +64,20 @@ const tables = [
   {
     TableName: 'FollowUps',
     KeySchema: [       
-      { AttributeName: 'uuid', KeyType: 'HASH' },
+      { AttributeName: 'id', KeyType: 'HASH' },
     ],
     AttributeDefinitions: [
-      { AttributeName: 'uuid', AttributeType: 'S' },
-      { AttributeName: 'emailReceivedAt', AttributeType: 'S' },
+      { AttributeName: 'id', AttributeType: 'S' },
       { AttributeName: 'regulationType', AttributeType: 'S' },
     ],
     BillingMode: 'PAY_PER_REQUEST',
     GlobalSecondaryIndexes: [
       {
-        IndexName: 'email_received_at_index',
+        IndexName: 'RegulationTypeIndex',
         KeySchema: [
           {
             AttributeName: 'regulationType',
             KeyType: 'HASH',
-          },
-          {
-            AttributeName: 'emailReceivedAt',
-            KeyType: 'RANGE',
           }
         ],
         Projection: {

--- a/setup/teardown-dynamo-tables.js
+++ b/setup/teardown-dynamo-tables.js
@@ -14,9 +14,9 @@ const tables = [
     TableName : "Requests"
   },
   {
-    FollowUps : "Requests"
+    TableName : "FollowUps"
   },
-]
+];
 
 tables.forEach((table) => {
   dynamodb.deleteTable(table, (err, data) => {

--- a/src/components/PersonalInfoForm/index.js
+++ b/src/components/PersonalInfoForm/index.js
@@ -186,6 +186,7 @@ class Form extends Component {
       requestParams.emailTo = to;
       requestParams.emailSubject = subject;
       requestParams.emailBody = body;
+      requestParams.lang = this.props.intl.locale;
     }
 
     fetch(
@@ -202,8 +203,8 @@ class Form extends Component {
     return mailtoLink({
       to,
       bcc,
-      subject: subject,
-      body: body,
+      subject,
+      body,
     });
   }
 

--- a/src/pages/api/save.js
+++ b/src/pages/api/save.js
@@ -55,7 +55,7 @@ export default async (req, res) => {
           {
             PutRequest: {
               Item: {
-                uuid: { S: req.body.uuid },
+                id: { S: req.body.uuid },
                 requestCreatedAt: { S: new Date().toISOString() },
                 requestType: { S: req.body.requestType },
                 regulationType: { S: req.body.regulationType },
@@ -71,12 +71,13 @@ export default async (req, res) => {
       if (
         !req.body.emailTo ||
         !req.body.emailSubject ||
-        !req.body.emailBody
+        !req.body.emailBody ||
+        !req.body.lang
       ) {
         res.setHeader('Content-Type', 'application/json');
         res.statusCode = 400;
         res.send({
-          error: 'Missing one of name, emailTo, emailSubject, emailBody',
+          error: 'Missing one of name, emailTo, emailSubject, emailBody, lang',
         });
         resolve();
         return;
@@ -86,7 +87,8 @@ export default async (req, res) => {
         {
           PutRequest: {
             Item: {
-              uuid: { S: req.body.uuid },
+              lang: { S: req.body.lang },
+              id: { S: req.body.uuid },
               requestCreatedAt: { S: new Date().toISOString() },
               requestType: { S: req.body.requestType },
               regulationType: { S: req.body.regulationType },


### PR DESCRIPTION
https://github.com/your-digital-rights/yourdigitalrights.org/issues/212
https://optoutworkspace.slack.com/archives/CLHQW3TB8/p1621335944001200

This PR includes two changes:
1. Aligns dynamo table properties with the new names in https://github.com/your-digital-rights/aws-backend/blob/master/lib/db-stack.ts. Local scripts are still needed, due to missing DynamoDB Local support from CDK.
2. Saves the user's `lang` in the follow up table, which allows for localization of emails.