### PR TITLE
fix: accept only bare domains on the add organization form, and guard translations in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
 
       - run: npm install --legacy-peer-deps
 
+      # Runs before the build, which rewrites lang/en.json, so this checks the
+      # committed translations rather than freshly extracted ones.
+      - run: npm run check:i18n
+
       - run: npx playwright install --with-deps chromium
 
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "deploy:prod1": "npx vercel alias vercel alias https://opt-out.vercel.app/ yourdigitalrights.org",
     "clean": "rm -rf src/out && rm -rf src/.next && rm -rf ./next",
     "extract:i18n": "formatjs extract 'src/**/*.js' --format crowdin --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file lang/en.json",
-    "compile:i18n": "formatjs compile-folder --ast --format crowdin lang compiled-lang"
+    "compile:i18n": "formatjs compile-folder --ast --format crowdin lang compiled-lang",
+    "check:i18n": "node scripts/check-translations.js"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1000.0",

--- a/scripts/check-translations.js
+++ b/scripts/check-translations.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Fails when a translation references a variable the English source does not
+ * define.
+ *
+ * react-intl throws at render time in that case and falls back to the English
+ * text, so a single mistranslated placeholder silently breaks a page in one
+ * locale. It happened with org.titleExistingOrg, where three translations used
+ * {domain} while the source and the page pass {org}: every /d/ page view in
+ * those locales raised a FORMAT_ERROR.
+ *
+ * Crowdin does flag this, but the warning was dismissible, and the translations
+ * still reached the repo. This is the backstop that does not depend on Crowdin
+ * or on translators.
+ *
+ * The comparison is deliberately one-directional. A translation that *omits* a
+ * placeholder is not an error -- the value simply does not appear -- and plenty
+ * of locales legitimately do that. Only *extra* variables throw.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+let parse;
+try {
+  ({ parse } = require("@formatjs/icu-messageformat-parser"));
+} catch (error) {
+  console.error(
+    "Cannot load @formatjs/icu-messageformat-parser, which normally comes in\n" +
+    "with react-intl. Install it as a devDependency to run this check:\n" +
+    "  npm install --save-dev @formatjs/icu-messageformat-parser\n"
+  );
+  process.exit(1);
+}
+
+const LANG_DIR = path.join(__dirname, "..", "lang");
+const SOURCE_LOCALE = "en";
+
+// ICU element type ids, from @formatjs/icu-messageformat-parser.
+const TYPE = { argument: 1, number: 2, date: 3, time: 4, select: 5, plural: 6, tag: 8 };
+
+function messageOf(entry) {
+  return entry && typeof entry === "object" && "message" in entry ? entry.message : entry;
+}
+
+/** Every variable an ICU message actually reads, ignoring plural/select branch text. */
+function variablesIn(message) {
+  const found = new Set();
+
+  (function walk(elements) {
+    for (const element of elements) {
+      switch (element.type) {
+        case TYPE.argument:
+        case TYPE.number:
+        case TYPE.date:
+        case TYPE.time:
+          found.add(element.value);
+          break;
+        case TYPE.select:
+        case TYPE.plural:
+          found.add(element.value);
+          for (const option of Object.values(element.options || {})) {
+            walk(option.value);
+          }
+          break;
+        case TYPE.tag:
+          walk(element.children || []);
+          break;
+        default:
+          break;
+      }
+    }
+  })(parse(message));
+
+  return found;
+}
+
+function readCatalogue(locale) {
+  return JSON.parse(fs.readFileSync(path.join(LANG_DIR, `${locale}.json`), "utf8"));
+}
+
+const source = readCatalogue(SOURCE_LOCALE);
+const sourceVariables = {};
+for (const [id, entry] of Object.entries(source)) {
+  try {
+    sourceVariables[id] = variablesIn(messageOf(entry));
+  } catch (error) {
+    console.error(`${SOURCE_LOCALE}: ${id} is not parseable ICU -- ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const locales = fs
+  .readdirSync(LANG_DIR)
+  .filter(name => name.endsWith(".json"))
+  .map(name => name.replace(/\.json$/, ""))
+  .filter(locale => locale !== SOURCE_LOCALE);
+
+const problems = [];
+
+for (const locale of locales) {
+  const catalogue = readCatalogue(locale);
+
+  for (const [id, entry] of Object.entries(catalogue)) {
+    if (!(id in sourceVariables)) continue;
+
+    let used;
+    try {
+      used = variablesIn(messageOf(entry));
+    } catch (error) {
+      problems.push({ locale, id, detail: `not parseable ICU -- ${error.message}` });
+      continue;
+    }
+
+    const undefinedVariables = [...used].filter(name => !sourceVariables[id].has(name));
+    if (undefinedVariables.length) {
+      problems.push({
+        locale,
+        id,
+        detail:
+          `uses {${undefinedVariables.join("}, {")}} which the source never provides ` +
+          `(source provides ${[...sourceVariables[id]].map(v => `{${v}}`).join(", ") || "nothing"})`,
+      });
+    }
+  }
+}
+
+if (problems.length) {
+  console.error(`\n${problems.length} translation(s) reference a variable that is never provided:\n`);
+  for (const { locale, id, detail } of problems) {
+    console.error(`  ${locale}  ${id}`);
+    console.error(`      ${detail}`);
+  }
+  console.error(
+    "\nreact-intl throws on these at render time and falls back to English.\n" +
+    "Fix the placeholder in the translation, in Crowdin as well as in lang/.\n"
+  );
+  process.exit(1);
+}
+
+console.log(`Checked ${locales.length} locales against ${SOURCE_LOCALE}: no undefined variables.`);

--- a/src/components/PersonalInfoForm/index.js
+++ b/src/components/PersonalInfoForm/index.js
@@ -155,6 +155,45 @@ class Form extends Component {
     }, 300);
   };
 
+  invalidDomainMessage = () =>
+    this.props.intl.formatMessage({
+      id: "personalInfoForm.validDomain",
+      defaultMessage: "Please enter a domain only, for example example.com",
+    });
+
+  handleCompanyDomainInput = (event) => {
+    const value = event.target.value;
+    if (this.companyDomainValidationTimeout) {
+      clearTimeout(this.companyDomainValidationTimeout);
+    }
+    this.companyDomainValidationTimeout = setTimeout(() => {
+      // An empty field is left to the browser's own "required" handling, so that
+      // typing does not immediately complain before anything has been entered.
+      const companyDomainError = !value.trim() || normalizeDomainInput(value)
+        ? ""
+        : this.invalidDomainMessage();
+      this.companyDomainRef.current.setCustomValidity(companyDomainError);
+    }, 300);
+  };
+
+  // Rewrite the field to the bare hostname once the visitor moves on, so that a
+  // pasted "https://www.example.com/" becomes the "example.com" we will store
+  // and submit, and they can see exactly what is being recorded.
+  handleCompanyDomainBlur = () => {
+    const field = this.companyDomainRef.current;
+    if (!field || !field.value.trim()) {
+      return;
+    }
+
+    const normalized = normalizeDomainInput(field.value);
+    if (normalized) {
+      field.value = normalized;
+      field.setCustomValidity("");
+    } else {
+      field.setCustomValidity(this.invalidDomainMessage());
+    }
+  };
+
   handleFormSubmit = (e) => {
     e.preventDefault();
   };
@@ -362,6 +401,8 @@ class Form extends Component {
                 id="companyDomain"
                 label={CompanyDomainLabelText}
                 defaultValue=""
+                onChange={this.handleCompanyDomainInput}
+                onBlur={this.handleCompanyDomainBlur}
                 margin="normal"
                 required
                 helperText={CompanyDomainHelperText}

--- a/test/specs/form.spec.js
+++ b/test/specs/form.spec.js
@@ -148,6 +148,56 @@ test.describe('Form: add new organization', () => {
     expect(mailTo.body).toMatch(/10 Downing Street/);
     expect(mailTo.body).toMatch(/To the Attention of the Privacy Department/);
   });
+
+});
+
+// People paste whatever is in their address bar. The domain has to be reduced to
+// a bare hostname, because that is the form the domains dataset is keyed on, and
+// anything else leaves the request page unable to find the organization.
+test.describe('Form: organization domain normalization', () => {
+  async function openAddOrgForm(page) {
+    await page.setViewportSize({width: 1200, height: 823});
+    const p = await setupPageInDesktopView(page, '/', false);
+
+    await p.searchForm.fillInSearch('abcxyz123');
+    const addOrgResult = page.locator("li:has-text(\"Can't find an organization?\")");
+    await addOrgResult.waitFor({state: 'visible', timeout: 60_000});
+    await addOrgResult.click();
+    await page.waitForURL('**/d/add');
+
+    return p;
+  }
+
+  test('reduces a pasted address to a bare domain', async ({page}) => {
+    const p = await openAddOrgForm(page);
+    const domainField = await p.personalInfoForm.selectElementByLabel(
+      'Organization domain'
+    );
+
+    await p.personalInfoForm.fillIn(
+      'Organization domain',
+      'https://WWW.AbcXyz123.com/privacy?x=1'
+    );
+    await domainField.blur();
+
+    await expect(domainField).toHaveValue('abcxyz123.com');
+  });
+
+  test('refuses a value that is not a domain', async ({page}) => {
+    const p = await openAddOrgForm(page);
+    const domainField = await p.personalInfoForm.selectElementByLabel(
+      'Organization domain'
+    );
+
+    await p.personalInfoForm.fillIn('Organization domain', 'not a domain');
+    // Wait for the 300ms debounced validation to fire.
+    await page.waitForTimeout(500);
+    await domainField.blur();
+
+    expect(
+      await domainField.evaluate(el => el.validationMessage)
+    ).toMatch(/domain only/i);
+  });
 });
 
 test.describe('Form: invalid organization email', () => {


### PR DESCRIPTION
Two commits, both follow-ons from the request-page investigation.

---

## 1. The add organization form now accepts only bare domains

The organization domain field took whatever was typed. Real values that reached production through it:

```
https://www.midnight.co/
https://www.drscholls.com/
https://importkey.com/
```

The dataset is keyed on the bare hostname, so a stored value like that can never resolve, and the request page had nothing to show for it. The stored value and the review submission were already normalised in an earlier change, but the field itself gave no signal that a pasted address was wrong — so people kept entering them and the key kept needing repair after the fact.

The field now rewrites itself to the bare hostname when the visitor moves on: a pasted `https://WWW.Example.com/privacy?x=1` visibly becomes `example.com`, so they can see what is being recorded. A value that cannot be reduced to a domain sets a validation message and blocks submission.

This matches the existing organization email validation rather than introducing a second pattern — same debounce, same `setCustomValidity` approach. An empty field is deliberately left to the browser's own `required` handling so the form does not complain before anything has been entered. The helper text already asked for a domain, so no copy changed.

Covered by two Playwright tests in a self-contained describe block.

## 2. CI fails when a translation uses a variable that is never provided

react-intl throws at render time when a message references a variable that was not supplied, and falls back to the English text. A single mistranslated placeholder therefore breaks a page in one locale, silently, in production.

That is what happened with `org.titleExistingOrg`: three translations used `{domain}` while the source and the page pass `{org}`, so every `/d/` page view in Bulgarian, Danish and Croatian raised a `FORMAT_ERROR`. It was firing roughly 41 times per half hour, and nothing in the repo noticed. Those translations are now corrected here and in Crowdin, and Crowdin's variables check has been made non-dismissible — it was already flagging the mistake, but translators could click past it.

`scripts/check-translations.js` is the backstop that does not depend on Crowdin or on translators. It parses every message with the real ICU parser rather than matching braces, which matters: a naive regex reports 113 false problems, nearly all of them translators localising plural branch words such as `{days, plural, =0 {today} ...}`. The comparison is one-directional by design — a translation that *omits* a placeholder renders without the value and does not throw, so it is not flagged. Only extra variables are.

Runs before the build in CI, since the build rewrites `lang/en.json` and the committed translations are what needs checking. Verified both directions: passes across all 26 locales, and fails with a non-zero exit when the placeholder is reintroduced.

---

## Verification

`npm run build` clean. `npm run check:i18n` clean across 26 locales. The new form tests pass, as do the other `form.spec.js` tests.

One caveat: the first describe block in `form.spec.js` is flaky locally, failing as `tracks site search` or as a `beforeAll` timeout. It fails identically on a clean checkout, so it is unrelated to these changes — it drives the search through a live fetch of the 3.7MB domains list. Worth stubbing separately.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)